### PR TITLE
Fix typo in image download function name

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -265,7 +265,7 @@ class CarsParser:
             return 0
 
 
-    def dowload_images(self, vehicle_id: str, images: List) -> None:
+    def download_images(self, vehicle_id: str, images: List) -> None:
         """ Скачивает фотографии автомобиля и сохраняет их в папку с ID авто """
 
         folder_path = f"data/{vehicle_id}/images"
@@ -432,7 +432,7 @@ class CarsParser:
             images = soup.find("gallery-filmstrip").find_all("img")
             images = list(map(lambda image: image["src"], images))
 
-            self.dowload_images(vehicle_id, images)
+            self.download_images(vehicle_id, images)
             self.save_vehicle_info(vehicle_id, info)
 
         except:


### PR DESCRIPTION
## Summary
- rename `dowload_images` to `download_images`
- update references to the corrected method name

## Testing
- `python -m py_compile parser.py`


------
https://chatgpt.com/codex/tasks/task_b_68bde574f79c832691a86b6e0462e8a0