### PR TITLE
Handle missing user agent in proxy headers

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -171,8 +171,19 @@ class CarsParser:
             "https": f"http://{proxy_user}:{proxy_pass}@{proxy_host}:{proxy_port_http}",
         }
 
+        user_agent = self.user_agents.get(proxy_host)
+        if not user_agent:
+            try:
+                user_agent = UserAgent().random
+                self.user_agents[proxy_host] = user_agent
+            except Exception:
+                logging.warning(
+                    "Skipping proxy %s due to missing user-agent", proxy_host
+                )
+                return self.get_random_proxies_and_headers()
+
         headers = {
-            "User-Agent": self.user_agents[proxy_host]
+            "User-Agent": user_agent
         }
 
         return proxies, headers


### PR DESCRIPTION
## Summary
- Safely fetch proxy-specific user-agent by using `dict.get`
- Generate and cache a new user-agent when missing, warning if proxy skipped

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68be128dbfcc83269c8ef4a545935e85