### PR TITLE
Add simple Flask site to view car data with filters and stats

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,89 @@
+import json
+import os
+from types import SimpleNamespace
+from flask import Flask, render_template, request, abort
+
+app = Flask(__name__)
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), 'car_data')
+
+
+def _car_files():
+    for name in os.listdir(DATA_DIR):
+        if name.endswith('.json'):
+            yield os.path.join(DATA_DIR, name)
+
+
+def load_cars():
+    cars = []
+    for path in _car_files():
+        with open(path, 'r') as f:
+            data = json.load(f)
+            cars.append(SimpleNamespace(**data))
+    return cars
+
+
+def load_car(car_id):
+    path = os.path.join(DATA_DIR, f"{car_id}.json")
+    if not os.path.exists(path):
+        return None
+    with open(path, 'r') as f:
+        data = json.load(f)
+    return SimpleNamespace(**data)
+
+
+@app.route('/')
+def index():
+    cars = load_cars()
+
+    def apply_filters(car):
+        price_min = request.args.get('price_min', type=int)
+        price_max = request.args.get('price_max', type=int)
+        mileage_min = request.args.get('mileage_min', type=int)
+        mileage_max = request.args.get('mileage_max', type=int)
+        year_min = request.args.get('year_min', type=int)
+        year_max = request.args.get('year_max', type=int)
+
+        if price_min is not None and car.price < price_min:
+            return False
+        if price_max is not None and car.price > price_max:
+            return False
+        if mileage_min is not None and car.mileage < mileage_min:
+            return False
+        if mileage_max is not None and car.mileage > mileage_max:
+            return False
+        if year_min is not None and car.year < year_min:
+            return False
+        if year_max is not None and car.year > year_max:
+            return False
+        return True
+
+    cars = [c for c in cars if apply_filters(c)]
+
+    sort_key = request.args.get('sort')
+    order = request.args.get('order', 'asc')
+    if sort_key in {'price', 'mileage', 'year'}:
+        reverse = order == 'desc'
+        cars.sort(key=lambda c: getattr(c, sort_key, 0), reverse=reverse)
+
+    return render_template('index.html', cars=cars)
+
+
+@app.route('/view/<int:car_id>')
+def view_car(car_id: int):
+    car = load_car(car_id)
+    if not car:
+        abort(404)
+    return render_template('view.html', car=car)
+
+
+@app.route('/stat')
+def stat():
+    files = list(_car_files())
+    count = len(files)
+    total_size = sum(os.path.getsize(p) for p in files)
+    return render_template('stat.html', count=count, total_size=total_size)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/car_data/1.json
+++ b/car_data/1.json
@@ -1,0 +1,9 @@
+{
+  "id": 1,
+  "make": "Toyota",
+  "model": "Corolla",
+  "year": 2018,
+  "price": 15000,
+  "mileage": 30000,
+  "description": "Reliable compact car"
+}

--- a/car_data/2.json
+++ b/car_data/2.json
@@ -1,0 +1,9 @@
+{
+  "id": 2,
+  "make": "Honda",
+  "model": "Civic",
+  "year": 2020,
+  "price": 20000,
+  "mileage": 20000,
+  "description": "Sporty and efficient"
+}

--- a/car_data/3.json
+++ b/car_data/3.json
@@ -1,0 +1,9 @@
+{
+  "id": 3,
+  "make": "Ford",
+  "model": "Focus",
+  "year": 2015,
+  "price": 9000,
+  "mileage": 60000,
+  "description": "Economic hatchback"
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Cars</title>
+</head>
+<body>
+<h1>Cars</h1>
+<form method="get">
+    Price: <input name="price_min" placeholder="min" value="{{ request.args.get('price_min', '') }}">
+    - <input name="price_max" placeholder="max" value="{{ request.args.get('price_max', '') }}"><br>
+    Mileage: <input name="mileage_min" placeholder="min" value="{{ request.args.get('mileage_min', '') }}">
+    - <input name="mileage_max" placeholder="max" value="{{ request.args.get('mileage_max', '') }}"><br>
+    Year: <input name="year_min" placeholder="min" value="{{ request.args.get('year_min', '') }}">
+    - <input name="year_max" placeholder="max" value="{{ request.args.get('year_max', '') }}"><br>
+    Sort by:
+    <select name="sort">
+        <option value="">--</option>
+        <option value="price" {% if request.args.get('sort') == 'price' %}selected{% endif %}>Price</option>
+        <option value="mileage" {% if request.args.get('sort') == 'mileage' %}selected{% endif %}>Mileage</option>
+        <option value="year" {% if request.args.get('sort') == 'year' %}selected{% endif %}>Year</option>
+    </select>
+    <select name="order">
+        <option value="asc" {% if request.args.get('order', 'asc') == 'asc' %}selected{% endif %}>Asc</option>
+        <option value="desc" {% if request.args.get('order') == 'desc' %}selected{% endif %}>Desc</option>
+    </select>
+    <button type="submit">Apply</button>
+</form>
+<table border="1" cellpadding="5">
+<tr><th>ID</th><th>Make</th><th>Model</th><th>Year</th><th>Price</th><th>Mileage</th></tr>
+{% for car in cars %}
+<tr>
+    <td><a href="{{ url_for('view_car', car_id=car.id) }}">{{ car.id }}</a></td>
+    <td>{{ car.make }}</td>
+    <td>{{ car.model }}</td>
+    <td>{{ car.year }}</td>
+    <td>{{ car.price }}</td>
+    <td>{{ car.mileage }}</td>
+</tr>
+{% endfor %}
+</table>
+</body>
+</html>

--- a/templates/stat.html
+++ b/templates/stat.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Statistics</title>
+</head>
+<body>
+<h1>Statistics</h1>
+<ul>
+    <li>Total cars: {{ count }}</li>
+    <li>Total file size: {{ total_size }} bytes</li>
+</ul>
+<p><a href="{{ url_for('index') }}">Back to list</a></p>
+</body>
+</html>

--- a/templates/view.html
+++ b/templates/view.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Car {{ car.id }}</title>
+</head>
+<body>
+<h1>{{ car.make }} {{ car.model }}</h1>
+<ul>
+    <li>ID: {{ car.id }}</li>
+    <li>Year: {{ car.year }}</li>
+    <li>Price: {{ car.price }}</li>
+    <li>Mileage: {{ car.mileage }}</li>
+</ul>
+<p>{{ car.description }}</p>
+<p><a href="{{ url_for('index') }}">Back to list</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build a minimal Flask app to browse car data
- add index page with filtering and sorting by price, mileage, and year
- add detail view and statistics page showing car count and total file sizes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68be193d7d5483269f633b6637cf3f28