### PR TITLE
Handle empty proxy list in parser

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -168,6 +168,16 @@ class CarsParser:
     
     def get_random_proxies_and_headers(self) -> Tuple[Dict[str, str], Dict[str, str]]:
         """ Получает proxies и headers для GET-запроса в детерминированном порядке """
+        # When no proxies are configured, fall back to direct requests without
+        # proxy authentication.  Previously this resulted in a ZeroDivisionError
+        # when the proxies list was empty.
+        if not self.proxies:
+            try:
+                user_agent = UserAgent().random
+            except Exception:
+                user_agent = ""
+            headers = {"User-Agent": user_agent} if user_agent else {}
+            return {}, headers
 
         global _proxy_index
         with _proxy_index.get_lock():
@@ -196,9 +206,7 @@ class CarsParser:
                 )
                 return self.get_random_proxies_and_headers()
 
-        headers = {
-            "User-Agent": user_agent
-        }
+        headers = {"User-Agent": user_agent}
 
         return proxies, headers
     

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -58,6 +58,22 @@ def test_main_uses_load_proxies(tmp_path, monkeypatch):
     assert captured.get("ran")
 
 
+def test_get_random_proxies_and_headers_without_proxies(monkeypatch):
+    parser_instance = CarsParser([], "https://example.com", 1)
+
+    class DummyUA:
+        @property
+        def random(self):
+            return "agent"
+
+    monkeypatch.setattr(parser, "UserAgent", lambda: DummyUA())
+
+    proxies, headers = parser_instance.get_random_proxies_and_headers()
+
+    assert proxies == {}
+    assert headers == {"User-Agent": "agent"}
+
+
 def test_parse_basics_block_logs_url(parser_instance, caplog):
     soup = BeautifulSoup("<html></html>", "html.parser")
     url = "https://cars.com/vehicledetail/123"


### PR DESCRIPTION
## Summary
- avoid ZeroDivisionError when no proxies are configured
- add unit test for get_random_proxies_and_headers without proxies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68be1bb9b2588326af96d5d307fe7afb