### PR TITLE
Add browser-like headers to requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Cars Parser
+
+This project scrapes car listing data using rotating proxies.
+
+## Headers
+
+The parser sends requests with a set of browser-like headers. The
+`get_random_proxies_and_headers` helper returns a dictionary containing the
+following required keys:
+
+- `User-Agent`
+- `Accept`
+- `Accept-Language`
+- `Referer` (defaults to the base URL)
+- `Connection` (`keep-alive`)
+
+Tests or integrations that mock headers should include these fields to match
+the behaviour of the parser.
+

--- a/parser.py
+++ b/parser.py
@@ -167,7 +167,12 @@ class CarsParser:
 
     
     def get_random_proxies_and_headers(self) -> Tuple[Dict[str, str], Dict[str, str]]:
-        """ Получает proxies и headers для GET-запроса в детерминированном порядке """
+        """Получает proxies и набор заголовков, имитирующих браузер.
+
+        Заголовки включают стандартные поля ``User-Agent``, ``Accept``,
+        ``Accept-Language``, ``Referer`` и ``Connection``. Это помогает
+        уменьшить вероятность блокировки при выполнении HTTP-запросов.
+        """
         # When no proxies are configured, fall back to direct requests without
         # proxy authentication.  Previously this resulted in a ZeroDivisionError
         # when the proxies list was empty.
@@ -176,7 +181,14 @@ class CarsParser:
                 user_agent = UserAgent().random
             except Exception:
                 user_agent = ""
-            headers = {"User-Agent": user_agent} if user_agent else {}
+            headers = {
+                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+                "Accept-Language": "en-US,en;q=0.9",
+                "Referer": self.default_url,
+                "Connection": "keep-alive",
+            }
+            if user_agent:
+                headers["User-Agent"] = user_agent
             return {}, headers
 
         global _proxy_index
@@ -206,7 +218,13 @@ class CarsParser:
                 )
                 return self.get_random_proxies_and_headers()
 
-        headers = {"User-Agent": user_agent}
+        headers = {
+            "User-Agent": user_agent,
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Referer": self.default_url,
+            "Connection": "keep-alive",
+        }
 
         return proxies, headers
     

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -71,7 +71,13 @@ def test_get_random_proxies_and_headers_without_proxies(monkeypatch):
     proxies, headers = parser_instance.get_random_proxies_and_headers()
 
     assert proxies == {}
-    assert headers == {"User-Agent": "agent"}
+    assert headers == {
+        "User-Agent": "agent",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+        "Referer": "https://example.com",
+        "Connection": "keep-alive",
+    }
 
 
 def test_parse_basics_block_logs_url(parser_instance, caplog):


### PR DESCRIPTION
## Summary
- extend generated request headers with typical browser fields
- update tests for new header shape
- document required headers in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68be72ad8fb88326b5f59ef837b79f2d